### PR TITLE
드래그 시 과도하게 getDisplayedPosition 가 호출되는 문제 수정

### DIFF
--- a/main.js
+++ b/main.js
@@ -28,7 +28,7 @@ kakao.maps.event.addListener(map, 'center_changed', function() {
     var level = map.getLevel();
     var latlng = map.getCenter();
 
-    getDisplayedPosition()
+    debouncedGetDisplayedPosition()
 
 });
 
@@ -82,6 +82,15 @@ function getDisplayedPosition() {
         }
     });
 }
+
+function debounce (f, delay) {
+    var timeout = null;
+    return function () {
+        clearTimeout(timeout);
+        timeout = setTimeout(f, delay);
+    };
+}
+var debouncedGetDisplayedPosition = debounce(getDisplayedPosition, 500);
 
 function refreshData() {}
 


### PR DESCRIPTION
드래그 할 때마다 과도하게 getDisplayedPosition 가 호출되는 문제가 있어서 debounce 처리를 추가했습니다.